### PR TITLE
Added Code Analyzer for common mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ You can embed any assemblies you want by adding them to `<SGF_EmbeddedAssembly I
 Included with this package is a code analyzer that will be used to catch common mistakes when working with this library.
 
 
-### `SGF1001` SGFGeneratorAttributeApplied
+### `SGF1001`
+**Has SgfGenerator Attribute**
 
 Any class that inherits from `IncrementalGenerator` is required to have the `SgfGenerator` attribute applied to it. 
 
@@ -155,7 +156,9 @@ public class MyGenerator : IncrementalGenerator
 }
 ```
 
-### `SGF1002` ProhibitGeneratorAttribute
+### `SGF1002`
+
+**Prohibit Generator Attribute**
 
 If an `IncrementalGenerator` has the `Generator` attribute applied it will cause a compiler error. The reason being that the `Generator` attribute is used on classes that implement `IIncrementalGenerator` which `IncrementalGenerator` does not. SGF has it's own attribute to not confuse roslyn. SGFs `IncrementalGenerator` is run from within a wrapper to help capture exceptions and handle runtime type resolving. 
 
@@ -180,7 +183,8 @@ public class MyGenerator : IncrementalGenerator
 }
 ```
 
-### `SGF1003` HasDefaultConstructor
+### `SGF1003`
+**Has Default Constructor**
 
 `IncrementalGenerator` require a default constructor so they can be instantiated at runtime. If no constructor is defined the generator will never be run. 
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,84 @@ When your source generator runs it needs to find it's dependencies and this is o
 
 You can embed any assemblies you want by adding them to `<SGF_EmbeddedAssembly Include="Your Assembly Path"/>`
 
+## Diagnostic Analyzer
+
+Included with this package is a code analyzer that will be used to catch common mistakes when working with this library.
+
+
+### `SGF1001` SGFGeneratorAttributeApplied
+
+Any class that inherits from `IncrementalGenerator` is required to have the `SgfGenerator` attribute applied to it. 
+
+```cs
+// Error 
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator() : base("MyGenerator")
+    {}
+}
+```
+
+To fix the error just apply the attribute.
+
+```cs 
+// Fixed 
+[SgfGeneratorAttribute]
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator() : base("MyGenerator")
+    {}
+}
+```
+
+### `SGF1002` ProhibitGeneratorAttribute
+
+If an `IncrementalGenerator` has the `Generator` attribute applied it will cause a compiler error. The reason being that the `Generator` attribute is used on classes that implement `IIncrementalGenerator` which `IncrementalGenerator` does not. SGF has it's own attribute to not confuse roslyn. SGFs `IncrementalGenerator` is run from within a wrapper to help capture exceptions and handle runtime type resolving. 
+
+```cs
+// Error 
+[Generator]
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator() : base("MyGenerator")
+    {}
+}
+```
+
+To fix the error just remove the attribute.
+
+```cs 
+// Fixed 
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator() : base("MyGenerator")
+    {}
+}
+```
+
+### `SGF1003` HasDefaultConstructor
+
+`IncrementalGenerator` require a default constructor so they can be instantiated at runtime. If no constructor is defined the generator will never be run. 
+
+```cs
+// Error 
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator(string name) : base(name)
+    {}
+}
+```
+
+Add a default constructor that takes no arguments.
+
+```cs 
+// Fixed 
+public class MyGenerator : IncrementalGenerator 
+{
+    public MyGenerator() : base("MyGenerator")
+    {}
+}
+```
 
 ## Project Layout  
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@ namespace Example
     [SgfGenerator]
     public class ExampleSourceGenerator : IncrementalGenerator 
     {
-        // Constructor can only take two arguments in this order 
-        public ExampleSourceGenerator(
-            IGeneratorEnvironment generatorEnvironment, 
-            ILogger logger) : base("ExampleSourceGenerator", 
-            generatorPlatform, logger)
-        {$$
+        public ExampleSourceGenerator() : base("ExampleSourceGenerator")
+        {
             
         }
 

--- a/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleAppSourceGenerator.cs
+++ b/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleAppSourceGenerator.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.Text;
 using Newtonsoft.Json;
 using SGF;
-using SGF.Diagnostics;
 using System;
 using System.Text;
 

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/AnalyzerRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/AnalyzerRule.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System;
+
+namespace SGF.Analyzer.Rules
+{
+    internal abstract class AnalyzerRule
+    {
+        /// <summary>
+        /// Gets the descritor that this rule creates
+        /// </summary>
+        public DiagnosticDescriptor Descriptor { get; }
+
+        /// <summary>
+        /// Gets the current context 
+        /// </summary>
+        protected SyntaxNodeAnalysisContext Context { get; private set; }
+
+        public AnalyzerRule(DiagnosticDescriptor descriptor)
+        {
+            Descriptor = descriptor;
+        }
+
+        /// <summary>
+        /// Invokes the rule 
+        /// </summary>
+        public void Invoke(SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDeclaration)
+        {
+            Context = context;
+            try
+            {
+                Analyze(classDeclaration);
+            }
+            finally
+            {
+                Context = default;
+            }
+        }
+
+        /// <summary>
+        /// Tells the rule to analyze and report and errors that it sees
+        /// </summary>
+        protected abstract void Analyze(ClassDeclarationSyntax classDeclaration);
+
+        /// <summary>
+        /// Creates new <see cref="Diagnostic"/> using the <see cref="Descriptor"/> and reports
+        /// it to the current context
+        /// </summary>
+        /// <param name="location">The location to put the diagnostic</param>
+        /// <param name="messageArgs">Arguments that are used for it</param>
+        protected void ReportDiagnostic(Location location, params object[] messageArgs)
+        {
+            Diagnostic diagnostic = Diagnostic.Create(Descriptor, location, messageArgs); ;
+            Context.ReportDiagnostic(diagnostic);
+        }
+
+        protected bool TryGetAttribute(ClassDeclarationSyntax classDeclaration, string name, out AttributeSyntax? attribute)
+            => TryGetAttribute(classDeclaration, name, StringComparison.Ordinal, out attribute);
+
+        protected bool TryGetAttribute(ClassDeclarationSyntax classDeclaration, string name, StringComparison stringComparison, out AttributeSyntax? attribute)
+        {
+            attribute = GetAttribute(classDeclaration, name);
+            return attribute != null;
+        }
+
+        protected AttributeSyntax? GetAttribute(ClassDeclarationSyntax classDeclarationSyntax, string name, StringComparison stringComparison = StringComparison.Ordinal)
+        {
+            const string POSTFIX = "Attribute";
+
+            string alterntiveName = name.EndsWith(POSTFIX, StringComparison.Ordinal)
+                ? name.Substring(0, name.Length - POSTFIX.Length)
+                : $"{name}{POSTFIX}";
+
+            foreach (AttributeListSyntax attributeList in classDeclarationSyntax.AttributeLists)
+            {
+                foreach (AttributeSyntax attribute in attributeList.Attributes)
+                {
+                    string attributeName = attribute.Name.ToString();
+
+                    if (string.Equals(attributeName, name, stringComparison) ||
+                       string.Equals(attributeName, alterntiveName, stringComparison))
+                    {
+                        return attribute;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns back if the attribute with the given name is applied to the type
+        /// </summary>
+        protected bool HasAttribute(ClassDeclarationSyntax classDeclarationSyntax, string name, StringComparison stringComparison = StringComparison.Ordinal)
+            => GetAttribute(classDeclarationSyntax, name, stringComparison) != null;
+    }
+}

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
@@ -17,6 +17,7 @@ namespace SGF.Analyzer.Rules
 
         protected override void Analyze(ClassDeclarationSyntax classDeclaration)
         {
+            
             if (TryGetAttribute(classDeclaration, nameof(GeneratorAttribute), out AttributeSyntax? attributeSyntax))
             {
                 Location location = attributeSyntax!.GetLocation();
@@ -26,7 +27,7 @@ namespace SGF.Analyzer.Rules
 
         private static DiagnosticDescriptor CreateDescriptor()
             => new DiagnosticDescriptor("SGF1002",
-                "ProhibitGeneratorAttribute",
+                "Prohibit GeneratorAttribute",
                 $"{{0}} has the {nameof(GeneratorAttribute)} which can't be applied to classes which are inheirting from the Generator Foundations type {nameof(IncrementalGenerator)}.",
                 "SourceGeneration",
                 DiagnosticSeverity.Error,

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace SGF.Analyzer.Rules
+{
+    /// <summary>
+    /// Ensures tha the <see cref="GeneratorAttribute"/> is not applied to 
+    /// <see cref="IncrementalGenerator"/> as these types are not really <see cref="IIncrementalGenerator"/>
+    /// and won't be pickedup by Roslyn. 
+    /// </summary>
+    internal class ProhibitGeneratorAttributeRule : AnalyzerRule
+    {
+        public ProhibitGeneratorAttributeRule() : base(CreateDescriptor())
+        {
+
+        }
+
+        protected override void Analyze(ClassDeclarationSyntax classDeclaration)
+        {
+            if (TryGetAttribute(classDeclaration, nameof(GeneratorAttribute), out AttributeSyntax? attributeSyntax))
+            {
+                Location location = attributeSyntax!.GetLocation();
+                ReportDiagnostic(location, classDeclaration.Identifier.Text);
+            }
+        }
+
+        private static DiagnosticDescriptor CreateDescriptor()
+            => new DiagnosticDescriptor("SGF1002",
+                "ProhibitGeneratorAttribute",
+                $"{{0}} has the {nameof(GeneratorAttribute)} which can't be applied to classes which are inheirting from the Generator Foundations type {nameof(IncrementalGenerator)}.",
+                "SourceGeneration",
+                DiagnosticSeverity.Error,
+                true,
+                $"Incremental Generators should not have the {nameof(GeneratorAttribute)} applied to them.");
+    }
+}

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/ProhibitGeneratorAttributeRule.cs
@@ -32,6 +32,7 @@ namespace SGF.Analyzer.Rules
                 "SourceGeneration",
                 DiagnosticSeverity.Error,
                 true,
-                $"Incremental Generators should not have the {nameof(GeneratorAttribute)} applied to them.");
+                $"Incremental Generators should not have the {nameof(GeneratorAttribute)} applied to them.",
+                "https://github.com/ByronMayne/SourceGenerator.Foundations?tab=readme-ov-file#sgf1002");
     }
 }

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
@@ -45,7 +45,8 @@ namespace SGF.Analyzer.Rules
                         "SourceGeneration",
                         DiagnosticSeverity.Error,
                         true,
-                        "SGF Incremental Generators must have a default constructor otherwise they will not be run");
+                        "SGF Incremental Generators must have a default constructor otherwise they will not be run",
+                        "https://github.com/ByronMayne/SourceGenerator.Foundations?tab=readme-ov-file#sgf1003");
         }
     }
 }

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace SGF.Analyzer.Rules
+{
+    /// <summary>
+    /// Ensures that <see cref="IncrementalGenerator"/> types have a default
+    /// constructor defined.
+    /// </summary>
+    internal class RequireDefaultConstructorRule : AnalyzerRule
+    {
+        public RequireDefaultConstructorRule() : base(CreateDescriptor())
+        {
+        }
+
+        protected override void Analyze(ClassDeclarationSyntax classDeclaration)
+        {
+            ConstructorDeclarationSyntax[] constructors = classDeclaration.Members
+                .OfType<ConstructorDeclarationSyntax>()
+                .ToArray();
+
+            if(constructors.Length == 0)
+            {
+                // Already a compiler error since you need to call the base class constructor
+                return;
+            }
+
+            if(constructors.Any(c => c.ParameterList.Parameters.Count == 0))
+            {
+                // We have a default constructor 
+                return;
+            }
+
+
+            Location location = classDeclaration.Identifier.GetLocation();
+            ReportDiagnostic(location, classDeclaration.Identifier.Text);
+        }
+
+        private static DiagnosticDescriptor CreateDescriptor()
+        {
+            return new DiagnosticDescriptor("SGF1003",
+                        "SourceGeneratorHasDefaultConstructor",
+                        $"{{0}} is missing a default constructor",
+                        "SourceGeneration",
+                        DiagnosticSeverity.Error,
+                        true,
+                        "SGF Incremental Generators must have a default constructor otherwise they will not be run");
+        }
+    }
+}

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
@@ -40,7 +40,7 @@ namespace SGF.Analyzer.Rules
         private static DiagnosticDescriptor CreateDescriptor()
         {
             return new DiagnosticDescriptor("SGF1003",
-                        "SourceGeneratorHasDefaultConstructor",
+                        "HasDefaultConstructor",
                         $"{{0}} is missing a default constructor",
                         "SourceGeneration",
                         DiagnosticSeverity.Error,

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
@@ -21,11 +21,11 @@ namespace SGF.Analyzer.Rules
 
         private static DiagnosticDescriptor CreateDescriptor()
             => new DiagnosticDescriptor("SGF1001",
-                "SourceGeneratorAttributeApplied",
+                "SGFGeneratorAttributeApplied",
                 $"{{0}} is missing the {nameof(SgfGeneratorAttribute)}",
                 "SourceGeneration",
                 DiagnosticSeverity.Error,
                 true,
-                $"Source generators are required to have the attribute {nameof(GeneratorAttribute)} applied to them otherwise the compiler won't invoke them");
+                $"Source generators are required to have the attribute {nameof(SgfGeneratorAttribute)} applied to them otherwise the compiler won't invoke them");
     }
 }

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace SGF.Analyzer.Rules
+{
+    internal class RequireSfgGeneratorAttributeRule : AnalyzerRule
+    {
+
+        public RequireSfgGeneratorAttributeRule() : base(CreateDescriptor())
+        {
+        }
+
+        protected override void Analyze(ClassDeclarationSyntax classDeclaration)
+        {
+            if (!HasAttribute(classDeclaration, nameof(SgfGeneratorAttribute)))
+            {
+                Location location = classDeclaration.Identifier.GetLocation();
+                ReportDiagnostic(location, classDeclaration.Identifier.Text);
+            }
+        }
+
+        private static DiagnosticDescriptor CreateDescriptor()
+            => new DiagnosticDescriptor("SGF1001",
+                "SourceGeneratorAttributeApplied",
+                $"{{0}} is missing the {nameof(SgfGeneratorAttribute)}",
+                "SourceGeneration",
+                DiagnosticSeverity.Error,
+                true,
+                $"Source generators are required to have the attribute {nameof(GeneratorAttribute)} applied to them otherwise the compiler won't invoke them");
+    }
+}

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
@@ -26,6 +26,7 @@ namespace SGF.Analyzer.Rules
                 "SourceGeneration",
                 DiagnosticSeverity.Error,
                 true,
-                $"Source generators are required to have the attribute {nameof(SgfGeneratorAttribute)} applied to them otherwise the compiler won't invoke them");
+                $"Source generators are required to have the attribute {nameof(SgfGeneratorAttribute)} applied to them otherwise the compiler won't invoke them",
+                "https://github.com/ByronMayne/SourceGenerator.Foundations?tab=readme-ov-file#sgf1001");
     }
 }


### PR DESCRIPTION
#11 

There is three analyzers defined that check for the following 
1. The generator has a default constructor 
2. The generator has the `[SgfGenerator]` attribute applied to it
3. The generator does not have the `[Generator]` attribute applied to it 