### PR TITLE
Feature to turn off emitting ModuleInitializerAttribute when bringing your own polyfills

### DIFF
--- a/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleApp.SourceGenerator.csproj
+++ b/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleApp.SourceGenerator.csproj
@@ -7,7 +7,12 @@
     <Platforms>AnyCPU;x64</Platforms>
     <AssemblySearchPath_UseOutDir>true</AssemblySearchPath_UseOutDir>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!--Uncomment if bringing your own polyfills-->
+    <!--<SgfAddModuleInitializerAttribute>false</SgfAddModuleInitializerAttribute>-->
   </PropertyGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="SgfAddModuleInitializerAttribute" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/SourceGenerator.Foundations/HoistSourceGenerator.cs
+++ b/src/SourceGenerator.Foundations/HoistSourceGenerator.cs
@@ -33,7 +33,13 @@ namespace SGF
         private void AddCoreTypes(SourceProductionContext context, AnalyzerConfigOptionsProvider optionsProvider)
         {
             string @namespace = "SGF";
-            context.AddSource("System_Runtime_CompilerServices_ModuleInitializerAttribute.g.cs", ModuleInitializerTemplate.Render());
+            var includeModuleInitializer = true;
+            
+            if (optionsProvider.GlobalOptions.TryGetValue("build_property.SgfAddModuleInitializerAttribute", out var val))
+                if(!string.IsNullOrWhiteSpace(val)) bool.TryParse(val, out includeModuleInitializer);
+
+            if (includeModuleInitializer)
+                context.AddSource("System_Runtime_CompilerServices_ModuleInitializerAttribute.g.cs", ModuleInitializerTemplate.Render());
             context.AddSource("SgfSourceGeneratorHoist.g.cs", SourceGeneratorHoistBase.RenderTemplate(@namespace));
             context.AddSource("SgfAssemblyResolver.g.cs", AssemblyResolverTemplate.Render(@namespace));
         }


### PR DESCRIPTION
Added ability to recognize CompilerVisibleProperty set properties for controlling source generator options.
Added new build project property SgfAddModuleInitializerAttribute which when included in a source gen project's build pipeline and set to false (most commonly set in the project's .csproj file) will prevent the SgfAddModuleInitializerAttribute polyfill from being emitted. Use case is when utilizing other polyfill libraries.

