### PR TITLE
Changed the class attribute for marking generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Source Generators are awesome but working with them can be a bit painful. This l
 To get started all you need to do is add the NuGet package reference. You may or may not have to restart Visual Studio for the new types to show up. Then implement the base class `IncrementalGenerator` and apply the `[SgfGenerator]` attribute to your type;
 
 ```cs
+using SGF;
+
 namespace Example
 {
     // IncrementalGenerator, is a generated type from `SourceGenerator.Foundations'
-    [SgfGenerator]
+    [IncrementalGenerator]
     public class ExampleSourceGenerator : IncrementalGenerator 
     {
         public ExampleSourceGenerator() : base("ExampleSourceGenerator")
@@ -148,7 +150,7 @@ To fix the error just apply the attribute.
 
 ```cs 
 // Fixed 
-[SgfGeneratorAttribute]
+[IncrementalGenerator]
 public class MyGenerator : IncrementalGenerator 
 {
     public MyGenerator() : base("MyGenerator")

--- a/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleAppSourceGenerator.cs
+++ b/src/Sandbox/ConsoleApp.SourceGenerator/ConsoleAppSourceGenerator.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace ConsoleApp.SourceGenerator
 {
-    [SgfGenerator]
+    [IncrementalGenerator]
     internal class ConsoleAppSourceGenerator : IncrementalGenerator
     {
         public class Payload

--- a/src/SourceGenerator.Foundations.Contracts/SgfGeneratorAttribute.cs
+++ b/src/SourceGenerator.Foundations.Contracts/SgfGeneratorAttribute.cs
@@ -7,8 +7,20 @@ namespace SGF
     /// that will have Source Generator Foundations wrapper generated around it. This adds
     /// better error handling and logging to the given generator.
     /// </summary>
+    [Obsolete($"Please use the {nameof(IncrementalGeneratorAttribute)} instead", error: false)]
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class SgfGeneratorAttribute : Attribute
     {
+    }
+
+    /// <summary>
+    /// Applied a class that inherits from <see cref="IncrementalGenerator"/>
+    /// that will have Source Generator Foundations wrapper generated around it. This adds
+    /// better error handling and logging to the given generator.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class IncrementalGeneratorAttribute : Attribute
+    {
+
     }
 }

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireSfgGeneratorAttributeRule.cs
@@ -12,21 +12,25 @@ namespace SGF.Analyzer.Rules
 
         protected override void Analyze(ClassDeclarationSyntax classDeclaration)
         {
-            if (!HasAttribute(classDeclaration, nameof(SgfGeneratorAttribute)))
+#pragma warning disable CS0618 // Type or member is obsolete
+            if ( !HasAttribute(classDeclaration, nameof(IncrementalGeneratorAttribute)) &&
+                !HasAttribute(classDeclaration, nameof(SgfGeneratorAttribute)))
             {
                 Location location = classDeclaration.Identifier.GetLocation();
                 ReportDiagnostic(location, classDeclaration.Identifier.Text);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
+
         }
 
         private static DiagnosticDescriptor CreateDescriptor()
             => new DiagnosticDescriptor("SGF1001",
                 "SGFGeneratorAttributeApplied",
-                $"{{0}} is missing the {nameof(SgfGeneratorAttribute)}",
+                $"{{0}} is missing the {nameof(IncrementalGeneratorAttribute)}",
                 "SourceGeneration",
                 DiagnosticSeverity.Error,
                 true,
-                $"Source generators are required to have the attribute {nameof(SgfGeneratorAttribute)} applied to them otherwise the compiler won't invoke them",
+                $"Source generators are required to have the attribute {nameof(IncrementalGeneratorAttribute)} applied to them otherwise the compiler won't invoke them",
                 "https://github.com/ByronMayne/SourceGenerator.Foundations?tab=readme-ov-file#sgf1001");
     }
 }

--- a/src/SourceGenerator.Foundations/HoistSourceGenerator.cs
+++ b/src/SourceGenerator.Foundations/HoistSourceGenerator.cs
@@ -66,11 +66,14 @@ namespace SGF
                     string fullName = attributeContainingTypeSymbol.ToDisplayString();
 
                     // Is the attribute the [EnumExtensions] attribute?
-                    if (fullName == "SGF.SgfGeneratorAttribute")
+#pragma warning disable CS0618 // Type or member is obsolete
+                    switch (fullName)
                     {
-                        // return the enum. Implementation shown in section 7.
-                        return SourceGeneratorDataModel.Create(classDeclarationSyntax, context.SemanticModel);
+                        case $"SGF.{nameof(IncrementalGeneratorAttribute)}":
+                        case $"SGF.{nameof(SgfGeneratorAttribute)}":
+                           return SourceGeneratorDataModel.Create(classDeclarationSyntax, context.SemanticModel);
                     }
+#pragma warning restore CS0618 // Type or member is obsolete
                 }
             }
 


### PR DESCRIPTION
The attribute was `[SgfGenerator]` but it was brought up on [Reddit ](https://www.reddit.com/r/dotnet/comments/1hmpxdd/comment/m3zyzo3/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)that this was not very good name. So I changed it to `[IncrementalGenerator]`. Both attributes work but the original one was marked as depreciated.

From: 
```cs
using SGF;

[SgfGenerator]
public class MyGenerator : IncrementalGenerator
{}
```

To: 
```cs
using SGF;

[IncrementalGenerator]
public class MyGenerator : IncrementalGenerator
{}
```

Both versions will work for generation but the original one was marked as deprecated 