### PR TITLE
Added a telemetry event for when a NuGet package is installed

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,9 +11,7 @@
     <SGfIco>$(MSBuildThisFileDirectory)..\img\icon.png</SGfIco>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- Icons -->
-    <ApplicationIcon>$(MSBuildThisFileDirectory)..\img\icon.ico</ApplicationIcon>
-
-    
+    <ApplicationIcon>$(MSBuildThisFileDirectory)..\img\icon.ico</ApplicationIcon>    
     <!-- Paths | SGF Core -->
     <SGFProjectDir>$(SGFSourceDir)SourceGenerator.Foundations\</SGFProjectDir>
     <SGFProjectPath>$(SGFProjectDir)SourceGenerator.Foundations.csproj</SGFProjectPath>
@@ -35,6 +33,10 @@
     <!-- Local Path Overrides | Both a local build and the nuget package use the same logic. This is used to override the paths when building locally -->
     <SGFMsBuildPath>$(LibsDir)SourceGenerator.Foundations.MSBuild\SourceGenerator.Foundations.MSBuild.dll</SGFMsBuildPath>
   </PropertyGroup>
+  <ItemGroup>
+      <!-- Powershell NuGet scripts-->
+    <None Include="$(MSBuildThisFileDirectory)Scripts/*.ps1" Pack="True" PackagePath="tools\%(FileName)%(Extension)" Visible="Visible" />
+  </ItemGroup>
   <!-- Debug Targets -->
   <Target Name="PrintSGFPaths">
     <Message Importance="high" Text="SGFProjectDir: $(SGFProjectDir)"/>

--- a/src/Scripts/Init.ps1
+++ b/src/Scripts/Init.ps1
@@ -1,0 +1,106 @@
+# Used to send a telemetry event whenever a package is installed. It does not
+# post any information that can be traced back to a user. It's used just so
+# I can see which projects are being used the most.
+
+param($installPath, $toolsPath, $package, $project)
+
+
+function Get-BuildAgent {
+
+    $agentKind = "None";
+
+    if(Test-Path env:APPVEYOR_API_URL) {
+        $agentKind = "AppVeyor";
+    }
+
+    if(Test-Path env:TF_BUILD) {
+        $agentKind = "AzurePipelines";
+    }
+
+    if(Test-Path env:BITBUCKET_WORKSPACE) {
+        $agentKind = "BitBucket";
+    }
+
+    if(Test-Path env:BUILDKITE) {
+        $agentKind = "BuildKite";
+    }
+
+    if(Test-Path env:CODEBUILD_WEBHOOK_HEAD_REF) {
+        $agentKind = "CodeBuild";
+    }
+
+    if(Test-Path env:ContinuaCI.Versin) {
+        $agentKind = "ContinuaCi";
+    }
+
+    if(Test-Path env:DRONE) {
+        $agentKind = "Drone";
+    }
+
+    if(Test-Path env:ENVRUN_DATABASE) {
+        $agentKind = "EnvRun";
+    }
+
+    if(Test-Path env:GITHUB_ACTIONS) {
+        $agentKind = "GitHubActions";
+    }
+
+    if(Test-Path env:GITLAB_CI) {
+        $agentKind = "GitLabCi";
+    }
+
+    if(Test-Path env:JENKINS_URL) {
+        $agentKind = "Jenkins";
+    }
+
+    if(Test-Path env:BuildRunner) {
+        $agentKind = "MyGet";
+    }
+
+    if(Test-Path env:SpaceAutomation) {
+        $agentKind = "MyGet";
+    }
+
+    if(Test-Path env:TEAMCITY_VERSION) {
+        $agentKind = "TeamCity";
+    }
+
+    if(Test-Path env:TRAVIS) {
+        $agentKind = "TravisCi";
+    }
+    return $agentKind;
+}
+
+$packageName = $package.Id;
+$packageVersion = $package.Version;
+$instrumentationKey = "43813c6c-bcf0-4610-bd97-9f6933a02b44"
+$applicationInsightsUrl = "https://dc.services.visualstudio.com/v2/track"
+$operationId = [guid]::NewGuid()
+$buildAgent = Get-BuildAgent
+$machineId = Get-ItemProperty HKLM:SOFTWARE\Microsoft\SQMClient | Select -ExpandProperty MachineID
+$machineId = $machineId.Substring(1, 36);
+
+$tracePayload = @{
+    name = "Microsoft.ApplicationInsights.Trace"
+    time = (Get-Date).ToString("o") 
+    iKey = $instrumentationKey
+    tags = @{
+        "ai.operation.id" = $operationId
+        "ai.cloud.role" = "NuGetScript"
+    }
+    data = @{
+        baseType = "MessageData"
+        baseData = @{
+            message = "package_init"
+            severityLevel = 1 # Verbose=0, Information=1, Warning=2, Error=3, Critical=4
+            properties = @{
+                "PackageName" = "$packageName"
+                "PackageVersion" = "$packageVersion"
+                "BuildAgent" = "$buildAgent"
+                "MachineId" = $machineId
+            }
+        }
+    }
+}
+$traceJson = $tracePayload | ConvertTo-Json -Depth 10 
+_ = Invoke-WebRequest -Uri $applicationInsightsUrl -Method Post -Body $traceJson -ContentType "application/json"


### PR DESCRIPTION
This was done so I can see which versions of the packages are being used. This does not track any data about the user or machine that can be tracked back to them.
