### PR TITLE
Enabling optional logging of adding sources

### DIFF
--- a/src/SourceGenerator.Foundations.Contracts/SgfSourceProductionContext.cs
+++ b/src/SourceGenerator.Foundations.Contracts/SgfSourceProductionContext.cs
@@ -33,14 +33,15 @@ namespace SGF
         }
 
         /// <inheritdoc/>
-        public void AddSource(string hintName, string source)
-            => AddSource(hintName, SourceText.From(source, Encoding.UTF8));
+        public void AddSource(string hintName, string source, bool logSourceAdded = true)
+            => AddSource(hintName, SourceText.From(source, Encoding.UTF8), logSourceAdded);
 
         /// <inheritdoc/>
-        public void AddSource(string hintName, SourceText sourceText)
+        public void AddSource(string hintName, SourceText sourceText, bool logSourceAdded = true)
         {
             SourceCount++;
-            m_generator.Logger.Information($" SourceAdded: {SourceCount}. {hintName}");
+            if( logSourceAdded )
+                m_generator.Logger.Information($" SourceAdded: {SourceCount}. {hintName}");
             m_context.AddSource(hintName, sourceText);
         }
 


### PR DESCRIPTION
Added a flag to function `AddSource` to optionally turn off the logging.

I have only edited on GitHub and have not tried compiling - hopefully the changes are syntactically OK.

Fixes #54 