### PR TITLE
Refactored Nuget publishing to use Trusted Publishers rather then api keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: sgf-bot 
+          user: ${{ secrets.NUGET_USER }} 
     
         # Release 
       - name: Push | ${{ matrix.project.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,4 +91,4 @@ jobs:
         # Release 
       - name: Push | ${{ matrix.project.name }}
         if: github.event_name == 'release' 
-        run: dotnet nuget push src\${{ matrix.project.name }}\bin\${{env.Configuration}}\*.nupkg --skip-duplicate -api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push src\${{ matrix.project.name }}\bin\${{env.Configuration}}\*.nupkg --skip-duplicate --api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
   publish:
     name: Publish | ${{ matrix.project.name }}
     runs-on: windows-latest
+    permissions:
+      id-token: write
     needs: 
       - test
     strategy:
@@ -77,7 +79,15 @@ jobs:
       # Pack 
       - name: Pack | ${{ matrix.project.name }}
         run: dotnet pack src\${{ matrix.project.name }}\${{ matrix.project.name }}.csproj -p:Version=${{env.GitVersion_AssemblySemVer}}  -p:PackageVersion=${{env.GitVersion_FullSemVer}} 
-      # Release 
+      
+    # Get a short-lived NuGet API key
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: sgf-bot 
+    
+        # Release 
       - name: Push | ${{ matrix.project.name }}
         if: github.event_name == 'release' 
-        run: dotnet nuget push src\${{ matrix.project.name }}\bin\${{env.Configuration}}\*.nupkg --skip-duplicate --api-key ${{secrets.NUGET_API_KEY}}  --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push src\${{ matrix.project.name }}\bin\${{env.Configuration}}\*.nupkg --skip-duplicate -api-key ${{steps.login.outputs.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     name: Publish | ${{ matrix.project.name }}
     runs-on: windows-latest
     permissions:
+      contents: read
       id-token: write
     needs: 
       - test


### PR DESCRIPTION
My API key had expired and failed to publish a new versions. Now Nuget supports trusted publishers which don't expire 

https://learn.microsoft.com/en-ca/nuget/nuget-org/trusted-publishing