### PR TITLE
Fixed the issue where abstract generators would trigger SGF1003

### DIFF
--- a/src/SourceGenerator.Foundations.Tests/DiagnosticAsserts.cs
+++ b/src/SourceGenerator.Foundations.Tests/DiagnosticAsserts.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using SGF.Analyzer.Rules;
 using System.Collections.Immutable;
 using System.Text;
 
@@ -15,6 +16,31 @@ namespace SourceGenerator.Foundations.Tests
         public static Action<ImmutableArray<Diagnostic>> NoErrorsOrWarnings()
             => NoneOfSeverity(DiagnosticSeverity.Warning, DiagnosticSeverity.Error);
 
+        /// <summary>
+        /// Asserts that the diagnostics contain a diagnostic for the specified rule.
+        /// </summary>
+        /// <typeparam name="TRule">The rule to check for</typeparam>
+        /// <returns></returns>
+        public static Action<ImmutableArray<Diagnostic>> TriggersRule<TRule>() where TRule : AnalyzerRule
+        {
+            string descriptorId = AnalyzerRule.GetDescriptorId<TRule>();
+
+            return diagnostics =>
+            {
+                if (diagnostics.Length == 0)
+                {
+                    Assert.Fail($"Expected diagnostic {descriptorId} but no diagnostics were emitted");
+                }
+
+                if (diagnostics.Any(d => d.Descriptor.Id == descriptorId))
+                {
+                    return;
+                }
+
+                Assert.Fail($"Expected diagnostic with ID '{descriptorId}' was not found in the emitted diagnostics. The emitted ones were ${string.Join(", ", diagnostics.Select(d => d.Descriptor.Id))}");
+            };
+        }
+
         public static Action<ImmutableArray<Diagnostic>> NoneOfSeverity(params DiagnosticSeverity[] severity)
         {
             HashSet<DiagnosticSeverity> set = new HashSet<DiagnosticSeverity>(severity);
@@ -25,11 +51,11 @@ namespace SourceGenerator.Foundations.Tests
                     .Where(d => set.Contains(d.Severity))
                     .ToList();
 
-                if(filtered.Count > 0)
+                if (filtered.Count > 0)
                 {
                     StringBuilder errorBuilder = new StringBuilder();
 
-                    foreach(var dia in filtered)
+                    foreach (var dia in filtered)
                     {
                         Location location = dia.Location;
                         string? filePath = Path.GetFileName(location.SourceTree?.FilePath);

--- a/src/SourceGenerator.Foundations.Tests/SourceGeneratorAnalyzerTests.cs
+++ b/src/SourceGenerator.Foundations.Tests/SourceGeneratorAnalyzerTests.cs
@@ -1,0 +1,64 @@
+﻿using SGF;
+using SGF.Analyzer;
+using SGF.Analyzer.Rules;
+using Xunit.Abstractions;
+
+namespace SourceGenerator.Foundations.Tests
+{
+    public class SourceGeneratorAnalyzerTests : CompilationTestBase
+    {
+        public SourceGeneratorAnalyzerTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+            AddAnalyzer<SourceGeneratorAnalyzer>();
+        }
+
+        [Fact]
+        public async Task Generates_Without_Default_Constructor_Emit_SGF1003()
+        {
+            string source = """
+                using SGF;
+                namespace Yellow
+                {
+                    [SgfGenerator]
+                    public class CustomGenerator : IncrementalGenerator
+                    {
+                        public CustomGenerator(string name) : base(name)
+                        {}
+                        public override void OnInitialize(SgfInitializationContext context)
+                        {}
+                    }
+                }
+                """;
+            await ComposeAsync([source],
+                assertDiagnostics: [
+                    DiagnosticAsserts.TriggersRule<RequireDefaultConstructorRule>()
+                ]);
+        }
+
+        [Fact]
+        public async Task Abstract_Generators_Dont_Trigger_SGF1003()
+        {
+            string source = """
+                using SGF;
+                namespace Yellow
+                {
+                    [SgfGenerator]
+                    public abstract class CustomGenerator : IncrementalGenerator
+                    {
+                        public CustomGenerator(string name) : base(name) 
+                        {
+                        }
+
+                        public override void OnInitialize(SgfInitializationContext context)
+                        {
+                        }
+                    }
+                }
+                """;
+            await ComposeAsync([source],
+                assertDiagnostics: [
+                    DiagnosticAsserts.NoErrors()
+                ]);
+        }
+    }
+}

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/AnalyzerRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/AnalyzerRule.cs
@@ -2,11 +2,15 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System;
+using System.Collections.Generic;
 
 namespace SGF.Analyzer.Rules
 {
     internal abstract class AnalyzerRule
     {
+        protected readonly static Dictionary<Type, string> s_ruleToDescriptorMap;
+
+
         /// <summary>
         /// Gets the descriptor that this rule creates
         /// </summary>
@@ -17,9 +21,15 @@ namespace SGF.Analyzer.Rules
         /// </summary>
         protected SyntaxNodeAnalysisContext Context { get; private set; }
 
+        static AnalyzerRule()
+        {
+            s_ruleToDescriptorMap = new Dictionary<Type, string>();
+        }
+
         public AnalyzerRule(DiagnosticDescriptor descriptor)
         {
             Descriptor = descriptor;
+            s_ruleToDescriptorMap[GetType()] = descriptor.Id;
         }
 
         /// <summary>
@@ -36,6 +46,17 @@ namespace SGF.Analyzer.Rules
             {
                 Context = default;
             }
+        }
+
+
+        /// <summary>
+        /// Gets the rule id for the given rule type
+        /// </summary>
+        /// <typeparam name="T">The type of the rule</typeparam>
+        /// <returns>The descriptor id for the given rule type</returns>
+        public static string GetDescriptorId<T>() where T : AnalyzerRule
+        {
+            return s_ruleToDescriptorMap[typeof(T)];
         }
 
         /// <summary>

--- a/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
+++ b/src/SourceGenerator.Foundations/Analyzer/Rules/RequireDefaultConstructorRule.cs
@@ -20,6 +20,13 @@ namespace SGF.Analyzer.Rules
                 .OfType<ConstructorDeclarationSyntax>()
                 .ToArray();
 
+            if(classDeclaration.Modifiers.Any(m => m.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AbstractKeyword)))
+            {
+                // Abstract classes do not need a default constructor, so we can skip this check
+                // Fix: https://github.com/ByronMayne/SourceGenerator.Foundations/issues/67
+                return;
+            }
+
             if(constructors.Length == 0)
             {
                 // Already a compiler error since you need to call the base class constructor


### PR DESCRIPTION
Fixes: https://github.com/ByronMayne/SourceGenerator.Foundations/issues/67

The issue was caused because the analyzer did not check if the class was abstract before emitting that it does not have a default constructor. 
